### PR TITLE
Add metadata and optimize list files

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -319,7 +319,8 @@ class Client
      * @param array $options
      * @return boolean
      */
-    public function fileExists(array $options) {
+    public function fileExists(array $options)
+    {
         $files = $this->listFiles($options);
 
         return !empty($files);

--- a/src/File.php
+++ b/src/File.php
@@ -10,6 +10,9 @@ class File
     protected $size;
     protected $type;
     protected $info;
+    protected $bucketId;
+    protected $action;
+    protected $uploadTimestamp;
 
     /**
      * File constructor.
@@ -20,8 +23,11 @@ class File
      * @param $size
      * @param $type
      * @param $info
+     * @param $bucketId
+     * @param $action
+     * @param $uploadTimestamp
      */
-    public function __construct($id, $name, $hash = null, $size = null, $type = null, $info = null)
+    public function __construct($id, $name, $hash = null, $size = null, $type = null, $info = null, $bucketId = null, $action = null, $uploadTimestamp = null)
     {
         $this->id = $id;
         $this->name = $name;
@@ -29,6 +35,9 @@ class File
         $this->size = $size;
         $this->type = $type;
         $this->info = $info;
+        $this->bucketId = $bucketId;
+        $this->action = $action;
+        $this->uploadTimestamp = $uploadTimestamp;
     }
 
     /**
@@ -77,5 +86,29 @@ class File
     public function getInfo()
     {
         return $this->info;
+    }
+
+    /**
+     * @return string
+     */
+    public function getBucketId()
+    {
+        return $this->bucketId;
+    }
+
+    /**
+     * @return string
+     */
+    public function getAction()
+    {
+        return $this->action;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUploadTimestamp()
+    {
+        return $this->uploadTimestamp;
     }
 }

--- a/tests/responses/get_file.json
+++ b/tests/responses/get_file.json
@@ -8,5 +8,7 @@
   "fileInfo": {
     "src_last_modified_millis": "1454721688784"
   },
+  "action": "upload",
+  "uploadTimestamp": "1465983870000",
   "fileName": "Test file.bin"
 }


### PR DESCRIPTION
When trying to add B2 support to [Imbo](https://github.com/imbo/imbo), I found a few small things that we need to support our storage API on B2:

Add support for the missing metadata from the `getFile()` method: uploadTimestamp, action and bucketId.

Optimize file list retrieval (`listFiles()`) to avoid fetching information about _all_ the files to get information about a single one. `listFiles` now supports an optional parameter, `FileName`, which will only retrieve information about that file if it exists. This speeds up the call to `getFileIdFromBucketAndFileName`.