### PR TITLE
Rename authorise => authorize

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -34,7 +34,7 @@ class Client
             $this->client = new HttpClient(['exceptions' => false]);
         }
 
-        $this->authoriseAccount();
+        $this->authorizeAccount();
     }
 
     /**
@@ -395,11 +395,11 @@ class Client
     }
 
     /**
-     * Authorise the B2 account in order to get an auth token and API/download URLs.
+     * Authorize the B2 account in order to get an auth token and API/download URLs.
      *
      * @throws \Exception
      */
-    protected function authoriseAccount()
+    protected function authorizeAccount()
     {
         $response = $this->client->request('GET', 'https://api.backblaze.com/b2api/v1/b2_authorize_account', [
             'auth' => [$this->accountId, $this->applicationKey]


### PR DESCRIPTION
While the spelling is interchangable outside of North America, the B2 API
uses authorize, so we should keep the same spelling here to minimize
confusion.

Fixes #6