### PR TITLE
Change authentication domain to api.backblazeb2.com

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -407,7 +407,7 @@ class Client
      */
     protected function authorizeAccount()
     {
-        $response = $this->client->request('GET', 'https://api.backblaze.com/b2api/v1/b2_authorize_account', [
+        $response = $this->client->request('GET', 'https://api.backblazeb2.com/b2api/v1/b2_authorize_account', [
             'auth' => [$this->accountId, $this->applicationKey]
         ]);
 


### PR DESCRIPTION
B2 requires the authentication domain to use the new api.backblazeb2.com
from February 2nd, 2017, but the change is already live for those who have
updated clients.