### PR TITLE
Update Client.php

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -194,7 +194,7 @@ class Client
         } else {
             // We've been given a simple string body, it's super simple to calculate the hash and size.
             $hash = sha1($options['Body']);
-            $size = mb_strlen($options['Body']);
+            $size = strlen($options['Body']);
         }
 
         if (!isset($options['FileLastModified'])) {


### PR DESCRIPTION
mb_strlen is not right here as files need to be considered in their "raw" format and not the ASCII parsed one,
This was causing the "Received error from B2: Sha1 did not match data received" Error.