### PR TITLE
Change mb_strlen() to strlen() for file size calculation (#1)

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -194,7 +194,7 @@ class Client
         } else {
             // We've been given a simple string body, it's super simple to calculate the hash and size.
             $hash = sha1($options['Body']);
-            $size = mb_strlen($options['Body']);
+            $size = strlen($options['Body']);
         }
 
         if (!isset($options['FileLastModified'])) {


### PR DESCRIPTION
Using mb_strlen() caused B2 to error out on certain files, because the file size wasn't calculated correctly. File size is not a multibyte-aware operation, it's just looking for the raw number of bytes.