### PR TITLE
Allow caching of authorization request

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -26,6 +26,7 @@ class Client
      */
     public function __construct($accountId, $applicationKey, array $options = [])
     {
+
         $this->accountId = $accountId;
         $this->applicationKey = $applicationKey;
 
@@ -34,8 +35,15 @@ class Client
         } else {
             $this->client = new HttpClient(['exceptions' => false]);
         }
+        
+        if(!empty($options['authorization'])){
+	        $this->authToken = $options['authorization']['authToken'];
+	        $this->apiUrl = $options['authorization']['apiUrl'];
+	        $this->downloadUrl = $options['authorization']['downloadUrl'];
+        } else {
+	        $this->authorizeAccount();
+        }
 
-        $this->authorizeAccount();
     }
 
     /**
@@ -398,6 +406,22 @@ class Client
         ]);
 
         return true;
+    }
+    
+    /**
+     * Retrieve authorization details from connection
+     *
+     * @return array
+     */
+    public function getAuthorization()
+    {
+		
+		return [
+			'authToken' 	=> $this->authToken,
+			'apiUrl'		=> $this->apiUrl,
+			'downloadUrl'	=> $this->downloadUrl
+		];
+		
     }
 
     /**


### PR DESCRIPTION
This pull requests adds a generic parameter to the construct option to provide an existing authorization object and allows you to get the authorization details from an existing connection. This way it is possible by the user to implement their own caching mechanism.

Example usage with Redis caching could be:

```
// Check if we have an authorization object available in Redis
$redis = \Redis::getInstance();
$auth = $redis->get('b2_auth');

if(!empty($auth)){
	
	// If available, decode object and use to init library
	$auth = json_decode($auth, true);
	$this->client = new \ChrisWhite\B2\Client(B2_ID, B2_KEY, ['authorization' => $auth]);
	
} else {
	
	// If not, generate init with new authorization request and save to Redis afterwards
	$this->client = new \ChrisWhite\B2\Client(B2_ID, B2_KEY);
	$authorization = $this->client->getAuthorization();
	
        // Save authorization object to Redis, expire in 23 hours so we don't use any expired tokens
	$redis->set('b2_auth', json_encode($authorization, JSON_UNESCAPED_SLASHES));
	$redis->expire('b2_auth', 60 * 60 * 23);	
	
}
```